### PR TITLE
feat(a11y): improve WCAG keyboard nav and semantic landmarks (Task #28)

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,28 @@
+# Accessibility Notes
+
+This document summarizes baseline accessibility support for Bitcoin Writer.
+
+## Current Improvements
+
+- Added a global "Skip to main content" link (`#main-content`).
+- Switched the main page content wrapper to a semantic `<main>` landmark.
+- Added global `:focus-visible` styles for keyboard navigation.
+- Added keyboard escape behavior to close Taskbar menus (`Esc`).
+- Added ARIA metadata to Taskbar toggles and icon-only navigation links.
+- Added ARIA metadata to the market ticker toggle and live update region.
+- Added ARIA labels and current-page metadata for dock app buttons.
+
+## Keyboard Behavior
+
+- `Tab`/`Shift+Tab`: navigate controls.
+- `Enter`/`Space`: activate buttons and links.
+- `Esc`: close open taskbar menus and mobile menu overlay.
+
+## Manual QA Checklist
+
+- [ ] Skip link is visible when tabbing from the top of the page.
+- [ ] Focus ring is visible on links, buttons, and form controls.
+- [ ] Taskbar menus open/close with keyboard and close on `Esc`.
+- [ ] Icon-only links have descriptive screen-reader names.
+- [ ] Ticker updates are announced politely (without interrupting reading).
+- [ ] Main flows are usable on mobile and desktop with keyboard only.

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,6 +18,29 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.skip-link {
+  position: fixed;
+  top: -48px;
+  left: 12px;
+  z-index: 20001;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: #f7931a;
+  color: #111;
+  text-decoration: none;
+  font-weight: 600;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus-visible {
+  top: 12px;
+}
+
+:where(a, button, input, select, textarea, [role='button'], [tabindex]):focus-visible {
+  outline: 2px solid #f7931a;
+  outline-offset: 2px;
+}
+
 #__next {
   min-height: 100%;
   display: flex;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout({
         <link rel="alternate icon" type="image/svg+xml" href="/logo.svg" />
       </head>
       <body>
+        <a href="#main-content" className="skip-link">Skip to main content</a>
         <div className="App">
           {/* Proof of Concept Banner - hide on /write page */}
           {!isWritePage && <ProofOfConceptBanner />}
@@ -93,9 +94,13 @@ export default function RootLayout({
           
           
           {/* Main Content */}
-          <div className={`main-content ${devSidebarCollapsed ? 'sidebar-collapsed' : 'sidebar-expanded'}`}>
+          <main
+            id="main-content"
+            className={`main-content ${devSidebarCollapsed ? 'sidebar-collapsed' : 'sidebar-expanded'}`}
+            tabIndex={-1}
+          >
             {children}
-          </div>
+          </main>
           
           {/* Dock - hide on /write page */}
           {!isWritePage && <DockManager currentApp="bitcoin-writer" />}

--- a/components/ui/CleanTaskbar.tsx
+++ b/components/ui/CleanTaskbar.tsx
@@ -410,10 +410,28 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setActiveMenu(null);
+        setShowBitcoinSuite(false);
+        setShowMobileMenu(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, []);
+
+  const getMenuId = (prefix: string, label: string) =>
+    `${prefix}-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+
   return (
     <>
     <div 
       ref={menuRef}
+      role="navigation"
+      aria-label="Main application menu bar"
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -434,10 +452,15 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
       {/* Bitcoin Logo */}
       <div style={{ position: 'relative' }}>
         <button
+          type="button"
           onClick={() => {
             setShowBitcoinSuite(!showBitcoinSuite);
             setActiveMenu(null);
           }}
+          aria-label="Toggle Bitcoin suite apps"
+          aria-haspopup="menu"
+          aria-expanded={showBitcoinSuite}
+          aria-controls="bitcoin-suite-menu"
           style={{
             padding: '0 20px 0 18px', // Shifted right to align with collapsed sidebar
             fontSize: '18px',
@@ -458,7 +481,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
 
         {/* Bitcoin Suite Dropdown */}
         {showBitcoinSuite && (
-          <div style={{
+          <div id="bitcoin-suite-menu" role="menu" style={{
             position: 'absolute',
             top: '32px',
             left: 0,
@@ -862,7 +885,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
         
         {/* Mobile Menu */}
         {isMobile && showMobileMenu && (
-          <div style={{
+          <div id="taskbar-mobile-menu" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" style={{
             position: 'fixed',
             top: '32px',
             left: 0,
@@ -914,7 +937,10 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               {menus.map((menu) => (
                 <div key={menu.label} style={{ marginBottom: '16px' }}>
                   <button
+                    type="button"
                     onClick={() => setActiveMenu(activeMenu === menu.label ? null : menu.label)}
+                    aria-expanded={activeMenu === menu.label}
+                    aria-controls={getMenuId('mobile-menu', menu.label)}
                     style={{
                       width: '100%',
                       padding: '10px',
@@ -934,13 +960,15 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
                   </button>
                   
                   {activeMenu === menu.label && (
-                    <div style={{ marginTop: '8px', paddingLeft: '12px' }}>
+                    <div id={getMenuId('mobile-menu', menu.label)} role="menu" style={{ marginTop: '8px', paddingLeft: '12px' }}>
                       {menu.items.map((item, index) => (
                         item.divider ? (
                           <div key={index} style={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', margin: '8px 0' }} />
                         ) : (
                           <button
+                            type="button"
                             key={index}
+                            role="menuitem"
                             onClick={() => {
                               if (item.href) {
                                 window.open(item.href, '_blank');
@@ -979,8 +1007,12 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
         {menus.map((menu) => (
           <div key={menu.label} style={{ position: 'relative' }}>
             <button
+              type="button"
               onClick={() => setActiveMenu(activeMenu === menu.label ? null : menu.label)}
               onMouseEnter={() => activeMenu && setActiveMenu(menu.label)}
+              aria-haspopup="menu"
+              aria-expanded={activeMenu === menu.label}
+              aria-controls={getMenuId('desktop-menu', menu.label)}
               style={{
                 padding: '0 12px',
                 height: '24px',
@@ -998,7 +1030,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
 
             {/* Dropdown Menu */}
             {activeMenu === menu.label && (
-              <div style={{
+              <div id={getMenuId('desktop-menu', menu.label)} role="menu" style={{
                 position: 'absolute',
                 top: '32px',
                 left: 0,
@@ -1028,6 +1060,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
                       href={item.href}
                       target="_blank"
                       rel="noopener noreferrer"
+                      role="menuitem"
                       style={{
                         display: 'flex',
                         justifyContent: 'space-between',
@@ -1053,7 +1086,9 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
                     </a>
                   ) : (
                     <button
+                      type="button"
                       key={index}
+                      role="menuitem"
                       onClick={() => {
                         item.action?.();
                         setActiveMenu(null);
@@ -1103,7 +1138,11 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
           gap: '8px'
         }}>
           <button
+            type="button"
             onClick={() => setShowMobileMenu(!showMobileMenu)}
+            aria-label="Toggle mobile menu"
+            aria-expanded={showMobileMenu}
+            aria-controls="taskbar-mobile-menu"
             style={{
               padding: '6px 12px',
               background: showMobileMenu ? 'rgba(255, 149, 0, 0.1)' : 'transparent',
@@ -1144,6 +1183,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
           {/* Docs Icon */}
           <a
             href="/docs"
+            aria-label="Open documentation"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1162,7 +1202,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
             </svg>
           </a>
@@ -1170,6 +1210,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
           {/* Token Icon */}
           <a
             href="/token"
+            aria-label="Open token page"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1196,6 +1237,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
           {/* Investors Icon */}
           <a
             href="/investors"
+            aria-label="Open investors page"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1216,7 +1258,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z"/>
             </svg>
           </a>
@@ -1224,6 +1266,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
           {/* Tasks Icon */}
           <a
             href="http://localhost:2010/contributions#tasks"
+            aria-label="Open contribution tasks"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1242,7 +1285,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M13.13 22.19l-1.63-3.83c-.11-.27-.4-.46-.7-.46h-1.6c-.3 0-.59.19-.7.46l-1.63 3.83c-.14.33.05.71.4.71h5.46c.35 0 .54-.38.4-.71zM5.64 12.5l-1.39 3.84c-.14.33.05.71.4.71h2.95c.3 0 .59-.19.7-.46l1.63-3.83c.14-.33-.05-.71-.4-.71H5.64zM18.36 12.5h-3.89c-.35 0-.54.38-.4.71l1.63 3.83c.11.27.4.46.7.46h2.95c.35 0 .54-.38.4-.71l-1.39-3.84zM12 2L8.5 8.5h7L12 2z"/>
             </svg>
           </a>
@@ -1252,6 +1295,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
             href="https://github.com/bitcoin-apps-suite/bitcoin-writer"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Open GitHub repository"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1270,7 +1314,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
             </svg>
           </a>
@@ -1280,6 +1324,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
             href="https://twitter.com/bitcoin_writer"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Open Twitter profile"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1298,7 +1343,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
             </svg>
           </a>
@@ -1308,6 +1353,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
             href="https://discord.gg/xBB8r8dj"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Open Discord server"
             style={{
               color: 'rgba(255, 255, 255, 0.8)',
               textDecoration: 'none',
@@ -1326,7 +1372,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
               e.currentTarget.style.color = 'rgba(255, 255, 255, 0.8)';
             }}
           >
-            <svg height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
+            <svg aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419-.0188 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9460 2.4189-2.1568 2.4189Z"/>
             </svg>
           </a>

--- a/components/ui/MinimalDock.tsx
+++ b/components/ui/MinimalDock.tsx
@@ -146,11 +146,25 @@ const MinimalDock: React.FC<MinimalDockProps> = ({ currentApp = 'bitcoin-writer'
     setIsHovered(false);
   };
 
+  const handleDockFocus = () => {
+    handleMouseEnter();
+  };
+
+  const handleDockBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      handleMouseLeave();
+    }
+  };
+
   return (
     <div 
       className={`minimal-dock ${isHovered ? 'hovered' : ''}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onFocus={handleDockFocus}
+      onBlur={handleDockBlur}
+      role="navigation"
+      aria-label="Bitcoin app dock"
     >
       <div className="minimal-dock-container">
         {/* All apps on the left */}
@@ -164,6 +178,8 @@ const MinimalDock: React.FC<MinimalDockProps> = ({ currentApp = 'bitcoin-writer'
                 onClick={() => handleAppClick(app)}
                 title={app.name}
                 disabled={app.disabled}
+                aria-label={`${app.name}${app.current ? ' (current app)' : ''}`}
+                aria-current={app.current ? 'page' : undefined}
               >
                 {app.id === 'bapps-store' ? (
                   <img src="/bapps-icon.jpg" alt="BAPPS" className="minimal-dock-icon-image" />
@@ -200,6 +216,7 @@ const MinimalDock: React.FC<MinimalDockProps> = ({ currentApp = 'bitcoin-writer'
                   className="minimal-dock-app-mini"
                   onClick={() => handleAppClick(app)}
                   title={app.name}
+                  aria-label={app.name}
                 >
                   {app.id === 'cashboard' ? (
                     <svg className="minimal-dock-icon-mini" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} style={{ color: getIconColor(app.color, index) }}>
@@ -227,21 +244,24 @@ const MinimalDock: React.FC<MinimalDockProps> = ({ currentApp = 'bitcoin-writer'
               className="minimal-dock-app-mini" 
               title="Switch to Large Dock" 
               onClick={toggleDockSize}
+              aria-label="Switch to large dock"
             >
               <Maximize2 className="minimal-dock-icon-mini" style={{ color: '#6b7280' }} />
             </button>
           </div>
           
           {/* System status */}
-          <div className="minimal-status-item" title="Connected">
+          <div className="minimal-status-item" title="Connected" role="img" aria-label="Network connected">
             <Wifi className="minimal-status-icon connected" />
           </div>
-          <div className="minimal-status-item" title="Battery: 100%">
+          <div className="minimal-status-item" title="Battery: 100%" role="img" aria-label="Battery 100 percent">
             <Battery className="minimal-status-icon connected" />
           </div>
           <div className="minimal-status-time" title={mounted ? currentTime.toLocaleDateString() : ''}>
             <Clock className="minimal-status-icon" />
-            <span>{mounted ? currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '12:00'}</span>
+            <time dateTime={currentTime.toISOString()}>
+              {mounted ? currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '12:00'}
+            </time>
           </div>
         </div>
       </div>

--- a/components/ui/TickerSidebar.tsx
+++ b/components/ui/TickerSidebar.tsx
@@ -29,6 +29,7 @@ const TickerSidebar: React.FC<TickerSidebarProps> = ({
   currentJobToken,
   onCollapsedChange
 }) => {
+  const tickerListId = 'ticker-market-list';
   const [prices, setPrices] = useState<TokenPrice[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
@@ -200,7 +201,11 @@ const TickerSidebar: React.FC<TickerSidebarProps> = ({
   };
 
   return (
-    <div className={`ticker-sidebar ${isCollapsed ? 'collapsed' : ''}`}>
+    <div
+      className={`ticker-sidebar ${isCollapsed ? 'collapsed' : ''}`}
+      role="region"
+      aria-label="BWRITER market ticker"
+    >
       <div className="ticker-header">
         <h3>$bWriter Market</h3>
         <div className="ticker-header-controls">
@@ -209,6 +214,9 @@ const TickerSidebar: React.FC<TickerSidebarProps> = ({
             className="ticker-toggle"
             onClick={handleToggleCollapsed}
             title={isCollapsed ? 'Expand ticker' : 'Collapse ticker'}
+            aria-label={isCollapsed ? 'Expand market ticker' : 'Collapse market ticker'}
+            aria-expanded={!isCollapsed}
+            aria-controls={tickerListId}
           >
             {isCollapsed ? '←' : '→'}
           </button>
@@ -218,9 +226,9 @@ const TickerSidebar: React.FC<TickerSidebarProps> = ({
       {!isCollapsed && (
         <>
           {isLoading ? (
-            <div className="ticker-loading">Loading prices...</div>
+            <div className="ticker-loading" role="status" aria-live="polite">Loading prices...</div>
           ) : (
-            <div className="ticker-list">
+            <div id={tickerListId} className="ticker-list" aria-live="polite" aria-atomic="false">
               {prices.map((token, index) => {
                 // Add divider after last special token
                 const showDivider = token.isSpecial && 
@@ -287,7 +295,8 @@ const TickerSidebar: React.FC<TickerSidebarProps> = ({
 
           <div className="ticker-footer">
             <div className="ticker-disclaimer">
-              Prices update every 30s
+              Prices update every 30s. Last update:{' '}
+              <time dateTime={lastUpdate.toISOString()}>{formatTime(lastUpdate)}</time>
             </div>
           </div>
         </>


### PR DESCRIPTION
## Summary
Implements core accessibility improvements for Task #28 (Accessibility Improvements).

### What changed
- Added global skip link (`Skip to main content`) and semantic `<main id="main-content">` landmark in app layout.
- Added global `:focus-visible` styles for links/buttons/inputs/selects/textarea/tabbable elements.
- Improved taskbar accessibility:
- ARIA labels on icon-only navigation links.
- `aria-expanded`, `aria-controls`, and menu roles for desktop/mobile menus.
- `Esc` key closes open menus and overlays.
- Improved dock accessibility:
- ARIA labels and current-page metadata for app buttons.
- Keyboard focus behavior and labeled system-status indicators.
- Improved ticker accessibility:
- Region labeling, toggle `aria-expanded`/`aria-controls`, polite live region updates, and last-update `<time>`.
- Added documentation: `ACCESSIBILITY.md` with keyboard behavior and manual QA checklist.

## Notes
- This PR targets the highest-impact WCAG 2.1 keyboard/screen-reader gaps first (navigation landmarks, focus visibility, icon controls, live updates).

## Validation
- `npm run build` could not complete in this environment due local disk-space limit (`ENOSPC`), not code compile regressions.

Closes #28
