### PR TITLE
feat: add writing analytics dashboard

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import Script from 'next/script';
+
+declare global {
+  interface Window {
+    BitcoinWriterAnalytics?: {
+      readState: () => any;
+      getSummary: (state: any) => AnalyticsSummary;
+      setDailyGoal: (goal: number) => any;
+    };
+  }
+}
+
+type DaySummary = {
+  dateKey: string;
+  label: string;
+  wordsWritten: number;
+  sessions: number;
+  goalMet: boolean;
+};
+
+type AnalyticsSummary = {
+  dailyGoal: number;
+  todayWords: number;
+  todaySessions: number;
+  goalProgress: number;
+  currentStreak: number;
+  longestStreak: number;
+  totalWordsWritten: number;
+  totalSessions: number;
+  bestDayWords: number;
+  activeDays: number;
+  averageWordsPerActiveDay: number;
+  last7Days: DaySummary[];
+  lastUpdatedAt: string | null;
+};
+
+const emptySummary: AnalyticsSummary = {
+  dailyGoal: 1000,
+  todayWords: 0,
+  todaySessions: 0,
+  goalProgress: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  totalWordsWritten: 0,
+  totalSessions: 0,
+  bestDayWords: 0,
+  activeDays: 0,
+  averageWordsPerActiveDay: 0,
+  last7Days: [],
+  lastUpdatedAt: null
+};
+
+export default function AnalyticsPage() {
+  const [summary, setSummary] = useState<AnalyticsSummary>(emptySummary);
+  const [goalInput, setGoalInput] = useState('1000');
+  const [loaded, setLoaded] = useState(false);
+
+  const refreshSummary = () => {
+    const analytics = window.BitcoinWriterAnalytics;
+    if (!analytics) {
+      return;
+    }
+
+    const nextSummary = analytics.getSummary(analytics.readState());
+    setSummary(nextSummary);
+    setGoalInput(String(nextSummary.dailyGoal));
+    setLoaded(true);
+  };
+
+  useEffect(() => {
+    refreshSummary();
+
+    const handleStorage = () => refreshSummary();
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const highestDailyValue = useMemo(() => {
+    const values = summary.last7Days.map((day) => day.wordsWritten);
+    return Math.max(summary.dailyGoal, 1, ...values);
+  }, [summary.dailyGoal, summary.last7Days]);
+
+  const saveGoal = () => {
+    const analytics = window.BitcoinWriterAnalytics;
+    if (!analytics) {
+      return;
+    }
+
+    const nextGoal = Number(goalInput);
+    if (!Number.isFinite(nextGoal) || nextGoal < 100) {
+      setGoalInput(String(summary.dailyGoal));
+      return;
+    }
+
+    analytics.setDailyGoal(nextGoal);
+    refreshSummary();
+  };
+
+  return (
+    <>
+      <Script src="/js/writing-analytics.js" strategy="beforeInteractive" onLoad={refreshSummary} />
+      <div
+        style={{
+          minHeight: '100vh',
+          background: 'radial-gradient(circle at top, rgba(247, 147, 26, 0.18), transparent 35%), #111111',
+          color: '#f4f4f4',
+          padding: '96px 24px 48px'
+        }}
+      >
+        <div style={{ maxWidth: '1120px', margin: '0 auto' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'space-between',
+              gap: '16px',
+              alignItems: 'flex-start',
+              marginBottom: '32px'
+            }}
+          >
+            <div>
+              <p style={{ color: '#f7931a', fontSize: '12px', letterSpacing: '0.18em', textTransform: 'uppercase', marginBottom: '8px' }}>
+                Writing Analytics
+              </p>
+              <h1 style={{ fontSize: '40px', lineHeight: 1.1, margin: 0 }}>Productivity Dashboard</h1>
+              <p style={{ color: '#b9b9b9', fontSize: '16px', maxWidth: '620px', marginTop: '12px' }}>
+                Track writing velocity, daily targets, and streaks across Bitcoin Writer sessions.
+              </p>
+            </div>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+              <Link
+                href="/write"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: '12px 18px',
+                  borderRadius: '12px',
+                  background: '#f7931a',
+                  color: '#111111',
+                  textDecoration: 'none',
+                  fontWeight: 700
+                }}
+              >
+                Back To Editor
+              </Link>
+              <button
+                type="button"
+                onClick={refreshSummary}
+                style={{
+                  padding: '12px 18px',
+                  borderRadius: '12px',
+                  border: '1px solid rgba(255,255,255,0.18)',
+                  background: 'rgba(255,255,255,0.04)',
+                  color: '#f4f4f4',
+                  fontWeight: 600,
+                  cursor: 'pointer'
+                }}
+              >
+                Refresh
+              </button>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: '16px',
+              marginBottom: '24px'
+            }}
+          >
+            {[
+              { label: 'Today', value: summary.todayWords.toLocaleString() + ' words', note: summary.todaySessions + ' sessions' },
+              { label: 'Current Streak', value: summary.currentStreak + ' days', note: 'Best: ' + summary.longestStreak + ' days' },
+              { label: 'Total Output', value: summary.totalWordsWritten.toLocaleString() + ' words', note: summary.activeDays + ' active days' },
+              { label: 'Best Day', value: summary.bestDayWords.toLocaleString() + ' words', note: 'Average active day: ' + summary.averageWordsPerActiveDay.toLocaleString() }
+            ].map((card) => (
+              <div
+                key={card.label}
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: '18px',
+                  padding: '20px'
+                }}
+              >
+                <div style={{ color: '#b0b0b0', fontSize: '13px', marginBottom: '10px' }}>{card.label}</div>
+                <div style={{ fontSize: '28px', fontWeight: 700, marginBottom: '8px' }}>{card.value}</div>
+                <div style={{ color: '#8f8f8f', fontSize: '13px' }}>{card.note}</div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 2fr) minmax(320px, 1fr)',
+              gap: '16px',
+              alignItems: 'start'
+            }}
+          >
+            <section
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '20px',
+                padding: '24px'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '16px', flexWrap: 'wrap', marginBottom: '20px' }}>
+                <div>
+                  <h2 style={{ margin: 0, fontSize: '22px' }}>Last 7 Days</h2>
+                  <p style={{ margin: '8px 0 0', color: '#9f9f9f' }}>Positive word deltas only. Deletions do not reduce your totals.</p>
+                </div>
+                <div style={{ color: '#9f9f9f', fontSize: '13px', alignSelf: 'center' }}>
+                  {summary.totalSessions.toLocaleString()} sessions recorded
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gap: '14px' }}>
+                {summary.last7Days.map((day) => {
+                  const width = Math.max(6, Math.round((day.wordsWritten / highestDailyValue) * 100));
+                  return (
+                    <div key={day.dateKey}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px', fontSize: '13px' }}>
+                        <span style={{ color: '#d7d7d7' }}>{day.label}</span>
+                        <span style={{ color: day.goalMet ? '#f7931a' : '#989898' }}>
+                          {day.wordsWritten.toLocaleString()} words · {day.sessions} sessions
+                        </span>
+                      </div>
+                      <div style={{ height: '12px', borderRadius: '999px', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+                        <div
+                          style={{
+                            width: width + '%',
+                            height: '100%',
+                            borderRadius: '999px',
+                            background: day.goalMet
+                              ? 'linear-gradient(90deg, #f7931a 0%, #ffb14d 100%)'
+                              : 'linear-gradient(90deg, #5a5a5a 0%, #818181 100%)',
+                            transition: 'width 0.25s ease'
+                          }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section
+              style={{
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '20px',
+                padding: '24px',
+                display: 'grid',
+                gap: '20px'
+              }}
+            >
+              <div>
+                <h2 style={{ margin: 0, fontSize: '22px' }}>Daily Goal</h2>
+                <p style={{ margin: '8px 0 0', color: '#9f9f9f' }}>Set a target that keeps your streak honest.</p>
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '14px', marginBottom: '8px' }}>
+                  <span>{summary.todayWords.toLocaleString()} / {summary.dailyGoal.toLocaleString()} words</span>
+                  <span>{Math.round(summary.goalProgress * 100)}%</span>
+                </div>
+                <div style={{ height: '14px', borderRadius: '999px', background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      width: Math.max(4, Math.round(summary.goalProgress * 100)) + '%',
+                      height: '100%',
+                      borderRadius: '999px',
+                      background: 'linear-gradient(90deg, #f7931a 0%, #ffcd75 100%)'
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gap: '10px' }}>
+                <label htmlFor="daily-goal" style={{ fontSize: '13px', color: '#bdbdbd' }}>Daily word goal</label>
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <input
+                    id="daily-goal"
+                    type="number"
+                    min={100}
+                    step={100}
+                    value={goalInput}
+                    onChange={(event) => setGoalInput(event.target.value)}
+                    style={{
+                      flex: 1,
+                      padding: '12px 14px',
+                      borderRadius: '12px',
+                      border: '1px solid rgba(255,255,255,0.14)',
+                      background: 'rgba(0,0,0,0.22)',
+                      color: '#f4f4f4'
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={saveGoal}
+                    style={{
+                      padding: '12px 16px',
+                      borderRadius: '12px',
+                      border: 'none',
+                      background: '#f7931a',
+                      color: '#111111',
+                      fontWeight: 700,
+                      cursor: 'pointer'
+                    }}
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+
+              <div style={{ paddingTop: '4px', borderTop: '1px solid rgba(255,255,255,0.08)', color: '#9f9f9f', fontSize: '13px', display: 'grid', gap: '8px' }}>
+                <div>Writers earn progress from net new words typed in the editor.</div>
+                <div>Sessions roll over after 5 minutes of inactivity.</div>
+                <div>{loaded ? 'Last updated: ' + (summary.lastUpdatedAt ? new Date(summary.lastUpdatedAt).toLocaleString() : 'No activity yet') : 'Loading analytics...'}</div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/editor/DocumentEditor_README.md
+++ b/components/editor/DocumentEditor_README.md
@@ -31,3 +31,9 @@ This component is dynamically imported in `app/page.tsx` to render the main edit
 ## Notes
 - Due to the component's original size (>1300 lines), it has been refactored into sub-components for maintainability.
 - Ensure import paths are correct after reorganization to avoid build errors.
+
+## Writing Analytics
+- The standalone editor now records analytics in browser storage under `bitcoin_writer_analytics`.
+- Metrics track net new words typed, per-day session counts, seven-day history, and streaks.
+- The analytics dashboard is available at `/analytics` and includes a configurable daily word goal.
+- Session boundaries roll over after five minutes of inactivity to keep productivity data realistic.

--- a/components/ui/CleanTaskbar.tsx
+++ b/components/ui/CleanTaskbar.tsx
@@ -312,7 +312,7 @@ const CleanTaskbar: React.FC<TaskbarProps> = ({
         }},
         { label: 'Export as PDF', action: () => window.print() },
         { divider: true },
-        { label: 'Analytics Dashboard', action: () => console.log('Open analytics') },
+        { label: 'Analytics Dashboard', action: () => { window.location.href = '/analytics'; } },
         { label: 'Create Calendar Event', action: () => console.log('Create event') }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "api": "API_PORT=3001 node api/server.js",
     "kill:all": "for port in {3000..3010}; do lsof -ti:$port | xargs kill -9 2>/dev/null || true; done",
     "deploy-token": "ts-node scripts/deploy-bwriter-token.ts",
-    "deploy-token:founder": "ts-node scripts/deploy-bwriter-token.ts"
+    "deploy-token:founder": "ts-node scripts/deploy-bwriter-token.ts",
+    "test:analytics": "node --test tests/writing-analytics.test.cjs"
   },
   "eslintConfig": {
     "extends": [

--- a/public/editor-standalone.html
+++ b/public/editor-standalone.html
@@ -517,6 +517,15 @@
         
         // Create app object if it doesn't exist
         window.app = window.app || {};
+
+        function getEditorWordCount() {
+            const editor = document.getElementById('editor');
+            if (!editor) return 0;
+
+            const rawText = editor.textContent || editor.innerText || '';
+            const text = rawText.trim() === 'Start typing...' ? '' : rawText;
+            return text.trim() ? text.trim().split(/\s+/).length : 0;
+        }
         
         // New Document function - uses documentTabsManager when available
         window.app.newDocument = function() {
@@ -551,18 +560,38 @@
             if (wordEl) wordEl.textContent = '0 words';
             const charEl = document.querySelector('#charCount span');
             if (charEl) charEl.textContent = '0 characters';
+
+            if (window.BitcoinWriterAnalytics) {
+                window.BitcoinWriterAnalytics.syncSessionWordCount(0, { resetStartedAt: true });
+            }
             
             return true;
         };
         
-        // Track editor changes
+        // Track editor changes and analytics
         document.addEventListener('DOMContentLoaded', function() {
             const editor = document.getElementById('editor');
             if (editor) {
+                let analyticsTimeout = null;
+
+                if (window.BitcoinWriterAnalytics) {
+                    window.BitcoinWriterAnalytics.syncSessionWordCount(getEditorWordCount(), { resetStartedAt: true });
+                }
+
                 editor.addEventListener('input', function() {
                     if (window.documentTabsManager && window.documentTabsManager.activeDocumentId) {
                         window.documentTabsManager.markDocumentModified(window.documentTabsManager.activeDocumentId);
                     }
+
+                    if (analyticsTimeout) {
+                        clearTimeout(analyticsTimeout);
+                    }
+
+                    analyticsTimeout = setTimeout(function() {
+                        if (window.BitcoinWriterAnalytics) {
+                            window.BitcoinWriterAnalytics.recordWordCountChange(getEditorWordCount());
+                        }
+                    }, 400);
                 });
             }
         });
@@ -571,6 +600,8 @@
         console.log('Document management initialized, window.app.newDocument:', window.app.newDocument);
     </script>
     
+    <script src="/js/writing-analytics.js"></script>
+
     <!-- Animated Placeholder Script -->
     <script>
         (function() {

--- a/public/js/writing-analytics.js
+++ b/public/js/writing-analytics.js
@@ -1,0 +1,380 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.BitcoinWriterAnalytics = factory();
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  var STORAGE_KEY = 'bitcoin_writer_analytics';
+  var DEFAULT_DAILY_GOAL = 1000;
+  var FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+  function toNonNegativeNumber(value, fallback) {
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return fallback;
+    }
+    return parsed;
+  }
+
+  function buildDateKey(input) {
+    var date = input instanceof Date ? input : new Date(input || Date.now());
+    var year = date.getFullYear();
+    var month = String(date.getMonth() + 1).padStart(2, '0');
+    var day = String(date.getDate()).padStart(2, '0');
+    return year + '-' + month + '-' + day;
+  }
+
+  function parseDateKey(dateKey) {
+    var parts = String(dateKey || '').split('-');
+    if (parts.length !== 3) {
+      return null;
+    }
+    var year = Number(parts[0]);
+    var month = Number(parts[1]);
+    var day = Number(parts[2]);
+    if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+      return null;
+    }
+    return new Date(year, month - 1, day);
+  }
+
+  function createDefaultState() {
+    return {
+      version: 1,
+      dailyGoal: DEFAULT_DAILY_GOAL,
+      totalWordsWritten: 0,
+      totalSessions: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      lastActiveDate: null,
+      lastUpdatedAt: null,
+      daily: {},
+      session: {
+        lastWordCount: null,
+        lastActivityAt: null,
+        startedAt: null,
+        activeDateKey: null
+      }
+    };
+  }
+
+  function createEmptyDay() {
+    return {
+      wordsWritten: 0,
+      sessions: 0,
+      highestWordCount: 0,
+      updatedAt: null
+    };
+  }
+
+  function normalizeDay(day) {
+    var base = createEmptyDay();
+    if (!day || typeof day !== 'object') {
+      return base;
+    }
+    return {
+      wordsWritten: toNonNegativeNumber(day.wordsWritten, 0),
+      sessions: toNonNegativeNumber(day.sessions, 0),
+      highestWordCount: toNonNegativeNumber(day.highestWordCount, 0),
+      updatedAt: day.updatedAt ? String(day.updatedAt) : null
+    };
+  }
+
+  function computeStreaks(daily, nowDateKey) {
+    var activeDays = Object.keys(daily || {})
+      .filter(function (dateKey) {
+        return daily[dateKey] && daily[dateKey].wordsWritten > 0;
+      })
+      .sort();
+
+    if (activeDays.length === 0) {
+      return { currentStreak: 0, longestStreak: 0 };
+    }
+
+    var longest = 1;
+    var running = 1;
+
+    for (var index = 1; index < activeDays.length; index += 1) {
+      var previous = parseDateKey(activeDays[index - 1]);
+      var current = parseDateKey(activeDays[index]);
+      if (!previous || !current) {
+        running = 1;
+      } else {
+        var difference = Math.round((current.getTime() - previous.getTime()) / 86400000);
+        running = difference === 1 ? running + 1 : 1;
+      }
+      if (running > longest) {
+        longest = running;
+      }
+    }
+
+    var currentStreak = 0;
+    if (activeDays[activeDays.length - 1] === nowDateKey) {
+      currentStreak = 1;
+      for (var reverseIndex = activeDays.length - 1; reverseIndex > 0; reverseIndex -= 1) {
+        var currentDate = parseDateKey(activeDays[reverseIndex]);
+        var previousDate = parseDateKey(activeDays[reverseIndex - 1]);
+        if (!currentDate || !previousDate) {
+          break;
+        }
+        var gap = Math.round((currentDate.getTime() - previousDate.getTime()) / 86400000);
+        if (gap !== 1) {
+          break;
+        }
+        currentStreak += 1;
+      }
+    }
+
+    return {
+      currentStreak: currentStreak,
+      longestStreak: longest
+    };
+  }
+
+  function normalizeState(input) {
+    var source = input && typeof input === 'object' ? input : {};
+    var state = {
+      version: 1,
+      dailyGoal: Math.max(100, toNonNegativeNumber(source.dailyGoal, DEFAULT_DAILY_GOAL) || DEFAULT_DAILY_GOAL),
+      totalWordsWritten: 0,
+      totalSessions: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      lastActiveDate: null,
+      lastUpdatedAt: source.lastUpdatedAt ? String(source.lastUpdatedAt) : null,
+      daily: {},
+      session: {
+        lastWordCount: source.session && source.session.lastWordCount !== null && source.session.lastWordCount !== undefined
+          ? toNonNegativeNumber(source.session.lastWordCount, 0)
+          : null,
+        lastActivityAt: source.session && source.session.lastActivityAt ? String(source.session.lastActivityAt) : null,
+        startedAt: source.session && source.session.startedAt ? String(source.session.startedAt) : null,
+        activeDateKey: source.session && source.session.activeDateKey ? String(source.session.activeDateKey) : null
+      }
+    };
+
+    Object.keys(source.daily || {}).forEach(function (dateKey) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) {
+        state.daily[dateKey] = normalizeDay(source.daily[dateKey]);
+      }
+    });
+
+    Object.keys(state.daily).sort().forEach(function (dateKey) {
+      var day = state.daily[dateKey];
+      state.totalWordsWritten += day.wordsWritten;
+      state.totalSessions += day.sessions;
+      if (day.wordsWritten > 0) {
+        state.lastActiveDate = dateKey;
+      }
+    });
+
+    var streaks = computeStreaks(state.daily, buildDateKey(new Date()));
+    state.currentStreak = streaks.currentStreak;
+    state.longestStreak = streaks.longestStreak;
+
+    return state;
+  }
+
+  function resolveStorage(storage) {
+    if (storage && typeof storage.getItem === 'function' && typeof storage.setItem === 'function') {
+      return storage;
+    }
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+    return null;
+  }
+
+  function readState(storage) {
+    var resolvedStorage = resolveStorage(storage);
+    if (!resolvedStorage) {
+      return createDefaultState();
+    }
+
+    try {
+      var raw = resolvedStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return createDefaultState();
+      }
+      return normalizeState(JSON.parse(raw));
+    } catch (error) {
+      return createDefaultState();
+    }
+  }
+
+  function writeState(state, storage) {
+    var resolvedStorage = resolveStorage(storage);
+    var normalized = normalizeState(state);
+    normalized.lastUpdatedAt = new Date().toISOString();
+
+    if (resolvedStorage) {
+      try {
+        resolvedStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+      } catch (error) {
+        return normalized;
+      }
+    }
+
+    return normalized;
+  }
+
+  function ensureDay(state, dateKey) {
+    if (!state.daily[dateKey]) {
+      state.daily[dateKey] = createEmptyDay();
+    }
+    return state.daily[dateKey];
+  }
+
+  function syncSessionWordCount(currentWordCount, options, storage) {
+    var now = options && options.now ? new Date(options.now) : new Date();
+    var state = readState(storage);
+    state.session.lastWordCount = toNonNegativeNumber(currentWordCount, 0);
+    state.session.lastActivityAt = now.toISOString();
+    state.session.activeDateKey = buildDateKey(now);
+
+    if (options && options.resetStartedAt) {
+      state.session.startedAt = null;
+    }
+
+    return writeState(state, storage);
+  }
+
+  function recordWordCountChange(currentWordCount, options, storage) {
+    var now = options && options.now ? new Date(options.now) : new Date();
+    var inactivityMs = options && options.inactivityMs
+      ? toNonNegativeNumber(options.inactivityMs, FIVE_MINUTES_MS)
+      : FIVE_MINUTES_MS;
+    var state = readState(storage);
+    var current = toNonNegativeNumber(currentWordCount, 0);
+    var previous = state.session.lastWordCount;
+    var dateKey = buildDateKey(now);
+    var day = ensureDay(state, dateKey);
+
+    if (previous === null || previous === undefined) {
+      state.session.lastWordCount = current;
+      state.session.lastActivityAt = now.toISOString();
+      state.session.activeDateKey = dateKey;
+      return writeState(state, storage);
+    }
+
+    var lastActivity = state.session.lastActivityAt ? new Date(state.session.lastActivityAt) : null;
+    var isStale = !state.session.startedAt || !lastActivity || Number.isNaN(lastActivity.getTime())
+      || (now.getTime() - lastActivity.getTime()) > inactivityMs
+      || state.session.activeDateKey !== dateKey;
+
+    if (isStale) {
+      day.sessions += 1;
+      state.session.startedAt = now.toISOString();
+    }
+
+    var positiveDelta = current > previous ? current - previous : 0;
+    if (positiveDelta > 0) {
+      day.wordsWritten += positiveDelta;
+      day.highestWordCount = Math.max(day.highestWordCount, current);
+      state.lastActiveDate = dateKey;
+    }
+
+    day.updatedAt = now.toISOString();
+    state.session.lastWordCount = current;
+    state.session.lastActivityAt = now.toISOString();
+    state.session.activeDateKey = dateKey;
+
+    return writeState(state, storage);
+  }
+
+  function setDailyGoal(nextGoal, storage) {
+    var state = readState(storage);
+    state.dailyGoal = Math.max(100, toNonNegativeNumber(nextGoal, DEFAULT_DAILY_GOAL) || DEFAULT_DAILY_GOAL);
+    return writeState(state, storage);
+  }
+
+  function formatLabel(dateKey) {
+    var date = parseDateKey(dateKey);
+    if (!date) {
+      return dateKey;
+    }
+
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  function listRecentDays(stateInput, options) {
+    var state = normalizeState(stateInput);
+    var days = options && options.days ? toNonNegativeNumber(options.days, 7) : 7;
+    var endDate = options && options.now ? new Date(options.now) : new Date();
+    endDate.setHours(0, 0, 0, 0);
+
+    var recentDays = [];
+    for (var offset = days - 1; offset >= 0; offset -= 1) {
+      var date = new Date(endDate);
+      date.setDate(endDate.getDate() - offset);
+      var dateKey = buildDateKey(date);
+      var day = state.daily[dateKey] || createEmptyDay();
+      recentDays.push({
+        dateKey: dateKey,
+        label: formatLabel(dateKey),
+        wordsWritten: day.wordsWritten,
+        sessions: day.sessions,
+        goalMet: day.wordsWritten >= state.dailyGoal
+      });
+    }
+
+    return recentDays;
+  }
+
+  function getSummary(stateInput, options) {
+    var state = normalizeState(stateInput);
+    var now = options && options.now ? new Date(options.now) : new Date();
+    var dateKey = buildDateKey(now);
+    var today = state.daily[dateKey] || createEmptyDay();
+    var last7Days = listRecentDays(state, { days: 7, now: now });
+    var bestDayWords = 0;
+    var activeDays = 0;
+
+    Object.keys(state.daily).forEach(function (dayKey) {
+      var day = state.daily[dayKey];
+      if (day.wordsWritten > bestDayWords) {
+        bestDayWords = day.wordsWritten;
+      }
+      if (day.wordsWritten > 0) {
+        activeDays += 1;
+      }
+    });
+
+    var streaks = computeStreaks(state.daily, dateKey);
+
+    return {
+      dailyGoal: state.dailyGoal,
+      todayWords: today.wordsWritten,
+      todaySessions: today.sessions,
+      goalProgress: state.dailyGoal > 0 ? Math.min(1, today.wordsWritten / state.dailyGoal) : 0,
+      currentStreak: streaks.currentStreak,
+      longestStreak: Math.max(state.longestStreak, streaks.longestStreak),
+      totalWordsWritten: state.totalWordsWritten,
+      totalSessions: state.totalSessions,
+      bestDayWords: bestDayWords,
+      activeDays: activeDays,
+      averageWordsPerActiveDay: activeDays > 0 ? Math.round(state.totalWordsWritten / activeDays) : 0,
+      last7Days: last7Days,
+      lastUpdatedAt: state.lastUpdatedAt
+    };
+  }
+
+  return {
+    STORAGE_KEY: STORAGE_KEY,
+    DEFAULT_DAILY_GOAL: DEFAULT_DAILY_GOAL,
+    buildDateKey: buildDateKey,
+    createDefaultState: createDefaultState,
+    computeStreaks: computeStreaks,
+    readState: readState,
+    writeState: writeState,
+    syncSessionWordCount: syncSessionWordCount,
+    recordWordCountChange: recordWordCountChange,
+    setDailyGoal: setDailyGoal,
+    listRecentDays: listRecentDays,
+    getSummary: getSummary
+  };
+});

--- a/tests/writing-analytics.test.cjs
+++ b/tests/writing-analytics.test.cjs
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const analytics = require('../public/js/writing-analytics.js');
+
+function createMemoryStorage() {
+  const state = new Map();
+  return {
+    getItem(key) {
+      return state.has(key) ? state.get(key) : null;
+    },
+    setItem(key, value) {
+      state.set(key, value);
+    },
+    removeItem(key) {
+      state.delete(key);
+    }
+  };
+}
+
+test('records positive word deltas and rolls sessions after inactivity', () => {
+  const storage = createMemoryStorage();
+
+  analytics.syncSessionWordCount(100, { now: '2026-03-10T09:00:00' }, storage);
+  analytics.recordWordCountChange(130, { now: '2026-03-10T09:01:00', inactivityMs: 300000 }, storage);
+  analytics.recordWordCountChange(125, { now: '2026-03-10T09:02:00', inactivityMs: 300000 }, storage);
+  analytics.recordWordCountChange(150, { now: '2026-03-10T09:10:30', inactivityMs: 300000 }, storage);
+
+  const summary = analytics.getSummary(analytics.readState(storage), { now: '2026-03-10T12:00:00' });
+
+  assert.equal(summary.todayWords, 55);
+  assert.equal(summary.todaySessions, 2);
+  assert.equal(summary.totalWordsWritten, 55);
+  assert.equal(summary.totalSessions, 2);
+});
+
+test('computes current and longest streaks from active writing days', () => {
+  const storage = createMemoryStorage();
+
+  analytics.syncSessionWordCount(0, { now: '2026-03-08T08:00:00', resetStartedAt: true }, storage);
+  analytics.recordWordCountChange(10, { now: '2026-03-08T08:10:00' }, storage);
+
+  analytics.syncSessionWordCount(0, { now: '2026-03-09T08:00:00', resetStartedAt: true }, storage);
+  analytics.recordWordCountChange(15, { now: '2026-03-09T08:10:00' }, storage);
+
+  analytics.syncSessionWordCount(0, { now: '2026-03-11T08:00:00', resetStartedAt: true }, storage);
+  analytics.recordWordCountChange(5, { now: '2026-03-11T08:10:00' }, storage);
+
+  const summary = analytics.getSummary(analytics.readState(storage), { now: '2026-03-11T12:00:00' });
+
+  assert.equal(summary.currentStreak, 1);
+  assert.equal(summary.longestStreak, 2);
+  assert.equal(summary.bestDayWords, 15);
+  assert.equal(summary.activeDays, 3);
+});


### PR DESCRIPTION
Closes #26

Summary:
- add a new /analytics dashboard with daily goal tracking, streaks, totals, and seven-day history
- record writing productivity from the standalone editor using browser storage and positive word deltas
- wire the existing Analytics Dashboard menu entry to the new page
- document the analytics behavior and add a small Node test for the core tracking logic

Testing:
- node --test tests/writing-analytics.test.cjs

Notes:
- analytics are stored locally in the browser under bitcoin_writer_analytics
- sessions roll over after 5 minutes of inactivity
- deletions do not reduce cumulative totals